### PR TITLE
remove duplicate story IDs from ref_array and fix regexp

### DIFF
--- a/post-commit
+++ b/post-commit
@@ -64,11 +64,11 @@ class GitLog
 
   def ids_from_refs
     ref_array = refs.split(',')
-    ref_array.inject([]) do |result, ref|
-      id = ref.scan(/\#(\d+)\D/i).flatten
+    ref_array.each_with_object([]) do |result, ref|
+      id = ref.scan(/\#(\d+)/).flatten
       result << "##{id.first}" unless id.empty?
       result
-    end.flatten
+    end.flatten.uniq
   end
 
   def to_json


### PR DESCRIPTION
The regexp didn't correspond to this README example: `feature/super-stuff-#85421170`

Before:
![fail](https://user-images.githubusercontent.com/1344/34537381-0fb85144-f07d-11e7-97e0-f873b2b4575d.png)

After:
![pass](https://user-images.githubusercontent.com/1344/34537410-2d1df5cc-f07d-11e7-9e25-4189c662989d.png)
